### PR TITLE
Add configuration to allow excluding ANC and ART options

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -23,3 +23,4 @@
 \.*gcov$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^diagram$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.options
 Title: Contains model and calibration options and helper functions for Naomi
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person(given = "Robert", 
            family = "Ashton", 

--- a/R/controls.R
+++ b/R/controls.R
@@ -65,7 +65,7 @@ get_calibration_options <- function() {
   )
 }
 
-get_model_controls <- function() {
+get_model_controls <- function(include_art, include_anc) {
   yes_no_options <- list(
     list(
       id = "true",
@@ -128,7 +128,7 @@ get_model_controls <- function() {
     )
   )
 
-  list(
+  controls <- list(
     area_scope = control(
       name = "area_scope",
       type = "multiselect",
@@ -229,79 +229,6 @@ get_model_controls <- function() {
     survey_art_coverage = control(
       name = "survey_art_coverage",
       type = "multiselect",
-      required = FALSE
-    ),
-    include_art_t1 = control(
-      name = "include_art_t1",
-      label = "OPTIONS_T1_LABEL",
-      type = "select",
-      help_text = "OPTIONS_T1_HELP",
-      required = TRUE,
-      options = yes_no_options
-    ),
-    include_art_t2 = control(
-      name = "include_art_t2",
-      label = "OPTIONS_T2_LABEL",
-      type = "select",
-      help_text = "OPTIONS_T2_HELP",
-      required = TRUE,
-      options = yes_no_options
-    ),
-    artattend = control(
-      name = "artattend",
-      type = "select",
-      help_text = "OPTIONS_ART_NEIGHBOURING_DISTRICT_HELP",
-      required = TRUE,
-      options = yes_no_options
-    ),
-    artattend_t2 = control(
-      name = "artattend_t2",
-      type = "select",
-      help_text = "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP",
-      required = TRUE,
-      options = yes_no_options
-    ),
-    anc_clients_year2 = control(
-      name = "anc_clients_year2",
-      label = "OPTIONS_T2_LABEL",
-      type = "select",
-      help_text = "OPTIONS_T2_HELP",
-      required = FALSE
-    ),
-    anc_clients_year2_num_months = control(
-      name = "anc_clients_year2_num_months",
-      label = "OPTIONS_T2_LABEL",
-      type = "select",
-      help_text = "OPTIONS_ANC_MONTHS_HELP",
-      required = TRUE,
-      options = month_options
-    ),
-    anc_prevalence_year1 = control(
-      name = "anc_prevalence_year1",
-      label = "OPTIONS_T1_LABEL",
-      type = "select",
-      help_text = "OPTIONS_T1_HELP",
-      required = FALSE
-    ),
-    anc_prevalence_year2 = control(
-      name = "anc_prevalence_year2",
-      label = "OPTIONS_T2_LABEL",
-      type = "select",
-      help_text = "OPTIONS_T2_HELP",
-      required = FALSE
-    ),
-    anc_art_coverage_year1 = control(
-      name = "anc_art_coverage_year1",
-      label = "OPTIONS_T1_LABEL",
-      type = "select",
-      help_text = "OPTIONS_T1_HELP",
-      required = FALSE
-    ),
-    anc_art_coverage_year2 = control(
-      name = "anc_art_coverage_year2",
-      label = "OPTIONS_T2_LABEL",
-      type = "select",
-      help_text = "OPTIONS_T2_HELP",
       required = FALSE
     ),
     spectrum_population_calibration = control(
@@ -424,6 +351,95 @@ get_model_controls <- function() {
       help_text = "OPTIONS_ADVANCED_DEFF_PROPORTION_RECENT_HELP"
     )
   )
+
+  if (include_anc) {
+    controls <- c(
+      controls,
+      list(
+        anc_clients_year2 = control(
+          name = "anc_clients_year2",
+          label = "OPTIONS_T2_LABEL",
+          type = "select",
+          help_text = "OPTIONS_T2_HELP",
+          required = FALSE
+        ),
+        anc_clients_year2_num_months = control(
+          name = "anc_clients_year2_num_months",
+          label = "OPTIONS_T2_LABEL",
+          type = "select",
+          help_text = "OPTIONS_ANC_MONTHS_HELP",
+          required = TRUE,
+          options = month_options
+        ),
+        anc_prevalence_year1 = control(
+          name = "anc_prevalence_year1",
+          label = "OPTIONS_T1_LABEL",
+          type = "select",
+          help_text = "OPTIONS_T1_HELP",
+          required = FALSE
+        ),
+        anc_prevalence_year2 = control(
+          name = "anc_prevalence_year2",
+          label = "OPTIONS_T2_LABEL",
+          type = "select",
+          help_text = "OPTIONS_T2_HELP",
+          required = FALSE
+        ),
+        anc_art_coverage_year1 = control(
+          name = "anc_art_coverage_year1",
+          label = "OPTIONS_T1_LABEL",
+          type = "select",
+          help_text = "OPTIONS_T1_HELP",
+          required = FALSE
+        ),
+        anc_art_coverage_year2 = control(
+          name = "anc_art_coverage_year2",
+          label = "OPTIONS_T2_LABEL",
+          type = "select",
+          help_text = "OPTIONS_T2_HELP",
+          required = FALSE
+        )
+      )
+    )
+  }
+  if (include_art) {
+    controls <- c(
+      controls,
+      list(
+        include_art_t1 = control(
+          name = "include_art_t1",
+          label = "OPTIONS_T1_LABEL",
+          type = "select",
+          help_text = "OPTIONS_T1_HELP",
+          required = TRUE,
+          options = yes_no_options
+        ),
+        include_art_t2 = control(
+          name = "include_art_t2",
+          label = "OPTIONS_T2_LABEL",
+          type = "select",
+          help_text = "OPTIONS_T2_HELP",
+          required = TRUE,
+          options = yes_no_options
+        ),
+        artattend = control(
+          name = "artattend",
+          type = "select",
+          help_text = "OPTIONS_ART_NEIGHBOURING_DISTRICT_HELP",
+          required = TRUE,
+          options = yes_no_options
+        ),
+        artattend_t2 = control(
+          name = "artattend_t2",
+          type = "select",
+          help_text = "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP",
+          required = TRUE,
+          options = yes_no_options
+        )
+      )
+    )
+  }
+  controls
 }
 
 get_calibration_controls <- function() {

--- a/R/options.R
+++ b/R/options.R
@@ -86,6 +86,10 @@ build_model_template <- function(include_art, include_anc) {
   if (nzchar(optional_controls)) {
     optional_controls <- paste0(optional_controls, ",")
   }
+  ## This is kind of gross but we want a way to have the template be
+  ## valid JSON and also have the ability to not include any additional
+  ## controls if users do not upload ANC or ART data. So we match and replace
+  ## the trailing ,
   glue::glue(template, .open = '"<~', .close = '~>",')
 }
 

--- a/R/options.R
+++ b/R/options.R
@@ -24,22 +24,35 @@
 #' )
 #' @param fallback_values A list of names values to use as fallbacks if
 #' hardcoded defaults are invalid.
+#' @param config Additional configuration options for returned JSON. If
+#' type is 'model' can set boolean 'include_art' and 'include_anc' to
+#' include options for ART and ANC controls. No affect for 'calibration' type.
 #'
 #' @return The complete controls JSON
 #' @export
-get_controls_json <- function(type, iso3, options, fallback_values) {
+get_controls_json <- function(type, iso3, options, fallback_values,
+                              config = list()) {
   ## TODO: Assert inputs are sensible
   switch(type,
-         "model" = build_model_controls(iso3, options, fallback_values),
+         "model" = build_model_controls(iso3, options, fallback_values, config),
          "calibration" = build_calibration_controls(iso3, options,
                                                     fallback_values),
          stop(t_("OPTIONS_UNKNOWN_TYPE", list(type = type))))
 }
 
-build_model_controls <- function(iso3, options, fallback_values) {
-  template <- read_template("model_options.json")
+build_model_controls <- function(iso3, options, fallback_values, config) {
+  include_art <- config$include_art
+  if (!isTRUE(config$include_art)) {
+    include_art <- FALSE
+  }
+  include_anc <- config$include_anc
+  if (!isTRUE(config$include_anc)) {
+    include_anc <- FALSE
+  }
 
-  controls <- get_model_controls()
+  template <- build_model_template(include_art, include_anc)
+
+  controls <- get_model_controls(include_art, include_anc)
   controls <- set_options(controls, options)
 
   defaults <- read_hardcoded_defaults(iso3, controls)
@@ -60,7 +73,21 @@ build_calibration_controls <- function(iso3, options, fallback_values) {
   build_json(template, controls)
 }
 
-
+build_model_template <- function(include_art, include_anc) {
+  template <- read_template("model_options.json")
+  additional <- list()
+  if (include_anc) {
+    additional <- c(additional, read_template("anc_options.json"))
+  }
+  if (include_art) {
+    additional <- c(additional, read_template("art_options.json"))
+  }
+  optional_controls <- paste(additional, collapse = ",")
+  if (nzchar(optional_controls)) {
+    optional_controls <- paste0(optional_controls, ",")
+  }
+  glue::glue(template, .open = '"<~', .close = '~>",')
+}
 
 read_template <- function(file_name) {
   template <- paste(readLines(system_file(file_name)),

--- a/inst/anc_options.json
+++ b/inst/anc_options.json
@@ -1,0 +1,32 @@
+{
+  "label": "t_(OPTIONS_ANC_LABEL)",
+  "description": "t_(OPTIONS_ANC_DESCRIPTION)",
+  "controlGroups": [
+    {
+      "label": "t_(OPTIONS_ANC_CLIENTS_LABEL)",
+      "controls": [
+        "<+anc_clients_year2+>"
+      ]
+    },
+    {
+      "label": "t_(OPTIONS_ANC_MONTHS_LABEL)",
+      "controls": [
+        "<+anc_clients_year2_num_months+>"
+      ]
+    },
+    {
+      "label": "t_(OPTIONS_ANC_PREVALENCE_LABEL)",
+      "controls": [
+        "<+anc_prevalence_year1+>",
+        "<+anc_prevalence_year2+>"
+      ]
+    },
+    {
+      "label": "t_(OPTIONS_ANC_COVERAGE_LABEL)",
+      "controls": [
+        "<+anc_art_coverage_year1+>",
+        "<+anc_art_coverage_year2+>"
+      ]
+    }
+  ]
+}

--- a/inst/art_options.json
+++ b/inst/art_options.json
@@ -1,0 +1,25 @@
+{
+  "label": "t_(OPTIONS_ART_LABEL)",
+  "description": "t_(OPTIONS_ART_DESCRIPTION)",
+  "controlGroups": [
+    {
+      "label": "t_(OPTIONS_ART_INCLUDE_ART_LABEL)",
+      "controls": [
+        "<+include_art_t1+>",
+        "<+include_art_t2+>"
+      ]
+    },
+    {
+      "label": "t_(OPTIONS_ART_NEIGHBOURING_DISTRICT_LABEL)",
+      "controls": [
+        "<+artattend+>"
+      ]
+    },
+    {
+      "label": "t_(OPTIONS_ART_TIME_VARYING_ART_ATTEND_LABEL)",
+      "controls": [
+        "<+artattend_t2+>"
+      ]
+    }
+  ]
+}

--- a/inst/model_options.json
+++ b/inst/model_options.json
@@ -54,63 +54,7 @@
         }
       ]
     },
-    {
-      "label": "t_(OPTIONS_ANC_LABEL)",
-      "description": "t_(OPTIONS_ANC_DESCRIPTION)",
-      "controlGroups": [
-        {
-          "label": "t_(OPTIONS_ANC_CLIENTS_LABEL)",
-          "controls": [
-            "<+anc_clients_year2+>"
-          ]
-        },
-        {
-          "label": "t_(OPTIONS_ANC_MONTHS_LABEL)",
-          "controls": [
-            "<+anc_clients_year2_num_months+>"
-          ]
-        },
-        {
-          "label": "t_(OPTIONS_ANC_PREVALENCE_LABEL)",
-          "controls": [
-            "<+anc_prevalence_year1+>",
-            "<+anc_prevalence_year2+>"
-          ]
-        },
-        {
-          "label": "t_(OPTIONS_ANC_COVERAGE_LABEL)",
-          "controls": [
-            "<+anc_art_coverage_year1+>",
-            "<+anc_art_coverage_year2+>"
-          ]
-        }
-      ]
-    },
-    {
-      "label": "t_(OPTIONS_ART_LABEL)",
-      "description": "t_(OPTIONS_ART_DESCRIPTION)",
-      "controlGroups": [
-        {
-          "label": "t_(OPTIONS_ART_INCLUDE_ART_LABEL)",
-          "controls": [
-            "<+include_art_t1+>",
-            "<+include_art_t2+>"
-          ]
-        },
-        {
-          "label": "t_(OPTIONS_ART_NEIGHBOURING_DISTRICT_LABEL)",
-          "controls": [
-            "<+artattend+>"
-          ]
-        },
-        {
-          "label": "t_(OPTIONS_ART_TIME_VARYING_ART_ATTEND_LABEL)",
-          "controls": [
-            "<+artattend_t2+>"
-          ]
-        }
-      ]
-    },
+    "<~optional_controls~>",
     {
       "label": "t_(OPTIONS_POPULATION_CALIBRATION_LABEL)",
       "description": "t_(OPTIONS_POPULATION_CALIBRATION_DESCRIPTION)",

--- a/man/get_controls_json.Rd
+++ b/man/get_controls_json.Rd
@@ -4,7 +4,7 @@
 \alias{get_controls_json}
 \title{Get the options JSON}
 \usage{
-get_controls_json(type, iso3, options, fallback_values)
+get_controls_json(type, iso3, options, fallback_values, config = list())
 }
 \arguments{
 \item{type}{The type of options to get, model or calibration}
@@ -29,6 +29,10 @@ label = "two"
 
 \item{fallback_values}{A list of names values to use as fallbacks if
 hardcoded defaults are invalid.}
+
+\item{config}{Additional configuration options for returned JSON. If
+type is 'model' can set boolean 'include_art' and 'include_anc' to
+include options for ART and ANC controls. No affect for 'calibration' type.}
 }
 \value{
 The complete controls JSON
@@ -39,6 +43,5 @@ country. The control info will be filled in in this order of precedence
 \enumerate{
 \item hardcoded default values from \code{default_options.csv}
 \item \code{fallback_values} arg (if set)
-\item Fallback value in \code{controls.R} (if set)
 }
 }

--- a/tests/testthat/helper-options.R
+++ b/tests/testthat/helper-options.R
@@ -1,6 +1,6 @@
 build_test_options <- function(iso3, type, additional_values) {
   if (type == "model") {
-    controls <- get_model_controls()
+    controls <- get_model_controls(TRUE, TRUE)
   } else {
     controls <- get_calibration_controls()
   }
@@ -39,7 +39,7 @@ build_test_options <- function(iso3, type, additional_values) {
 }
 
 get_control <- function(options_json, name) {
-  for (control_section in options_json$controlSection) {
+  for (control_section in options_json$controlSections) {
     for (control_group in control_section$controlGroups) {
       for (control in control_group$controls) {
         if (control$name == name) {

--- a/tests/testthat/test-options-valid.R
+++ b/tests/testthat/test-options-valid.R
@@ -7,7 +7,9 @@ test_that("default options produce valid JSON", {
     for (type in types) {
       withCallingHandlers({
         options <- build_test_options(country, type, NULL)
-        model_options <- get_controls_json(type, country, options, NULL)
+        model_options <- get_controls_json(
+          type, country, options, NULL,
+          list(include_art = TRUE, include_anc = TRUE))
         expect_true(validator(model_options, error = TRUE))
       },
       error = function(e) {

--- a/tests/testthat/test-read-defaults.R
+++ b/tests/testthat/test-read-defaults.R
@@ -1,5 +1,5 @@
 test_that("read_hardcoded_defaults sets types from controls", {
-  controls <- get_model_controls()
+  controls <- get_model_controls(TRUE, TRUE)
   defaults <- read_hardcoded_defaults("CMR", controls)
 
   expect_type(defaults, "list")
@@ -26,7 +26,7 @@ test_that("read_hardcoded_defaults filters defaults to set of controls", {
 })
 
 test_that("read_hardcoded_defaults sets NA columns to empty string", {
-  controls <- get_model_controls()
+  controls <- get_model_controls(TRUE, TRUE)
   defaults <- read_hardcoded_defaults("AGO", controls)
 
   expect_equal(defaults$survey_art_coverage, "")


### PR DESCRIPTION
I had forgotten these uploads were optional, so we need to be able to return it without these included in the JSON. This PR adds that ability through a `configuration` arg