### PR TITLE
Add calibration options label mapping helper function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.options
 Title: Contains model and calibration options and helper functions for Naomi
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
     person(given = "Robert", 
            family = "Ashton", 

--- a/R/controls.R
+++ b/R/controls.R
@@ -65,6 +65,40 @@ get_calibration_options <- function() {
   )
 }
 
+get_age_stratification_options <- function() {
+  list(
+    list(
+      id = "age_coarse",
+      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_AGE_COARSE_LABEL")
+    ),
+    list(
+      id = "sex_age_coarse",
+      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_SEX_AGE_COARSE_LABEL")
+    ),
+    list(
+      id = "age_group",
+      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_AGE_GROUP_LABEL")
+    ),
+    list(
+      id = "sex_age_group",
+      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_SEX_AGE_GROUP_LABEL")
+    )
+  )
+}
+
+get_calibrate_method_options <- function() {
+  list(
+    list(
+      id = "logistic",
+      label = t_("OPTIONS_CALIBRATE_METHOD_LOGISTIC_LABEL")
+    ),
+    list(
+      id = "proportional",
+      label = t_("OPTIONS_CALIBRATE_METHOD_PROPORTIONAL_LABEL")
+    )
+  )
+}
+
 get_model_controls <- function(include_art, include_anc) {
   yes_no_options <- list(
     list(
@@ -444,25 +478,7 @@ get_model_controls <- function(include_art, include_anc) {
 
 get_calibration_controls <- function() {
   calibration_level_opts <- get_calibration_options()
-
-  age_strat_opts <- list(
-    list(
-      id = "age_coarse",
-      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_AGE_COARSE_LABEL")
-    ),
-    list(
-      id = "sex_age_coarse",
-      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_SEX_AGE_COARSE_LABEL")
-    ),
-    list(
-      id = "age_group",
-      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_AGE_GROUP_LABEL")
-    ),
-    list(
-      id = "sex_age_group",
-      label = t_("OPTIONS_CALIBRATION_ADJUST_TO_SPECTRUM_SEX_AGE_GROUP_LABEL")
-    )
-  )
+  age_strat_opts <- get_age_stratification_options()
 
   list(
     spectrum_plhiv_calibration_level = control(
@@ -541,16 +557,7 @@ get_calibration_controls <- function() {
       name = "calibrate_method",
       type = "select",
       required = TRUE,
-      options = list(
-        list(
-          id = "logistic",
-          label = t_("OPTIONS_CALIBRATE_METHOD_LOGISTIC_LABEL")
-        ),
-        list(
-          id = "proportional",
-          label = t_("OPTIONS_CALIBRATE_METHOD_PROPORTIONAL_LABEL")
-        )
-      )
+      options = get_calibrate_method_options()
     )
   )
 }

--- a/R/labels.R
+++ b/R/labels.R
@@ -1,0 +1,24 @@
+#' Map calibration option ID to JSON calibration option labels
+#'
+#' @param options Key-value (calibration option name - calibration option ID)
+#' list of model options to be mapped.
+#'
+#' @return Mapped key-value (calibration option name - calibration option label)
+#' list of model options
+#' @export
+get_calibration_option_labels <- function(options) {
+  calibration_options <- c(get_calibration_options(),
+                           get_age_stratification_options(),
+                           get_calibrate_method_options())
+  ids <- vapply(calibration_options, "[[", character(1), "id")
+  labels <- vapply(calibration_options, "[[", character(1), "label")
+  map_option <- function(control_name) {
+    match <- ids == options[[control_name]]
+    if (sum(match) != 1) { ## i.e. there is 1 match
+      stop(t_("CALIBRATION_LABEL_FAILED", list(
+        control_name = control_name, value = options[[control_name]])))
+    }
+    labels[match]
+  }
+  as.list(vapply(names(options), map_option, character(1), USE.NAMES = TRUE))
+}

--- a/inst/traduire/en-translation.json
+++ b/inst/traduire/en-translation.json
@@ -104,5 +104,6 @@
   "OPTIONS_RECENTLY_INFECTED_LABEL": "Use survey data on proportion recently infected",
   "OPTIONS_ADVANCED_DEFF_PREVALENCE_LABEL": "Survey design effect - HIV prevalence",
   "OPTIONS_ADVANCED_DEFF_ART_COVERAGE_LABEL": "Survey design effect - ART coverage",
-  "OPTIONS_ADVANCED_DEFF_PROPORTION_RECENT_LABEL": "Survey design effect - Proportion recently infected"
+  "OPTIONS_ADVANCED_DEFF_PROPORTION_RECENT_LABEL": "Survey design effect - Proportion recently infected",
+  "CALIBRATION_LABEL_FAILED": "Failed to find calibration option label with name '{{control_name}}' and id '{{value}}'."
 }

--- a/inst/traduire/fr-translation.json
+++ b/inst/traduire/fr-translation.json
@@ -104,5 +104,6 @@
   "OPTIONS_T1_HELP": "Année correspondant au point médian de l'enquête",
   "OPTIONS_T2_HELP": "Année pour laquelle les estimations doivent être générées",
   "OPTIONS_ART_NEIGHBOURING_DISTRICT_HELP": "Proportion modèle de résidents sous TARV soignés dans les districts voisins",
-  "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP": "Permettre à la probabilité de demander un traitement dans les districts voisins de changer avec le temps"
+  "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP": "Permettre à la probabilité de demander un traitement dans les districts voisins de changer avec le temps",
+  "CALIBRATION_LABEL_FAILED": "Impossible de trouver une option de calibration avec le nom {{option_name}} et l'id {{value}}"
 }

--- a/inst/traduire/pt-translation.json
+++ b/inst/traduire/pt-translation.json
@@ -104,5 +104,6 @@
   "OPTIONS_T1_HELP": "Ano correspondente no ponto médio do inquérito",
   "OPTIONS_T2_HELP": "Ano para gerar estimativas para",
   "OPTIONS_ART_NEIGHBOURING_DISTRICT_HELP": "Proporção modelo de residentes em TARV que procuram tratamento em distritos vizinhos",
-  "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP": "Permitir que as probabilidades de procurar tratamento no distrito vizinho mudem ao longo do tempo."
+  "OPTIONS_ART_TIME_VARYING_ART_ATTEND_HELP": "Permitir que as probabilidades de procurar tratamento no distrito vizinho mudem ao longo do tempo.",
+  "CALIBRATION_LABEL_FAILED": "Falha em encontrar a opção de calibração com nome {{option_name}} e id {{value}}"
 }

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -1,0 +1,30 @@
+test_that("can get model calibration options label from ID", {
+  options <- list(spectrum_population_calibration_level = "subnational",
+                  spectrum_plhiv_calibration_strat = "sex_age_group" ,
+                  spectrum_artnum_calibration_level = "none",
+                  spectrum_artnum_calibration_strat = "age_coarse",
+                  spectrum_aware_calibration_level = "none",
+                  spectrum_aware_calibration_strat = "age_coarse",
+                  spectrum_infections_calibration_level = "none",
+                  spectrum_infections_calibration_strat ="age_coarse",
+                  calibrate_method = "logistic")
+  options_map <- get_calibration_option_labels(options)
+
+  expect_length(options_map, length(options))
+  expect_equal(options_map, list(
+    spectrum_population_calibration_level = "Subnational",
+    spectrum_plhiv_calibration_strat = "Sex and 5-year age group",
+    spectrum_artnum_calibration_level = "None",
+    spectrum_artnum_calibration_strat = "Age <15 / 15+",
+    spectrum_aware_calibration_level = "None",
+    spectrum_aware_calibration_strat = "Age <15 / 15+",
+    spectrum_infections_calibration_level = "None",
+    spectrum_infections_calibration_strat ="Age <15 / 15+",
+    calibrate_method = "Logistic"))
+})
+
+test_that("get_calibration_option_labels throws error if cannot be mapped", {
+  expect_error(
+    get_calibration_option_labels(list(test = "value")),
+    "Failed to find calibration option label with name 'test' and id 'value'.")
+})

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -1,12 +1,12 @@
 test_that("can get model calibration options label from ID", {
   options <- list(spectrum_population_calibration_level = "subnational",
-                  spectrum_plhiv_calibration_strat = "sex_age_group" ,
+                  spectrum_plhiv_calibration_strat = "sex_age_group",
                   spectrum_artnum_calibration_level = "none",
                   spectrum_artnum_calibration_strat = "age_coarse",
                   spectrum_aware_calibration_level = "none",
                   spectrum_aware_calibration_strat = "age_coarse",
                   spectrum_infections_calibration_level = "none",
-                  spectrum_infections_calibration_strat ="age_coarse",
+                  spectrum_infections_calibration_strat = "age_coarse",
                   calibrate_method = "logistic")
   options_map <- get_calibration_option_labels(options)
 
@@ -19,7 +19,7 @@ test_that("can get model calibration options label from ID", {
     spectrum_aware_calibration_level = "None",
     spectrum_aware_calibration_strat = "Age <15 / 15+",
     spectrum_infections_calibration_level = "None",
-    spectrum_infections_calibration_strat ="Age <15 / 15+",
+    spectrum_infections_calibration_strat = "Age <15 / 15+",
     calibrate_method = "Logistic"))
 })
 


### PR DESCRIPTION
This will replace the same function in naomi in a way that duplicates less info. Note it is not perfect as we still are manually pulling the possible options that the calibrate controls can take whereas we could get this from the control specification by the name of the control. This is a bit complicated wanting to call this on both calibration and model fit controls. I think this is a fine interim as the options we use for calibration do not change often.