### PR TITLE
remove calendar_quarter_t5 advanced option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: naomi.options
 Title: Contains model and calibration options and helper functions for Naomi
-Version: 1.3.0
+Version: 1.3.1
 Authors@R: 
     person(given = "Robert", 
            family = "Ashton", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# naomi.options 1.3.1
+
+* Remove `calendar_quarter_t5` option. Aligned to Naomi version 2.10.8.
+
 # naomi.options 1.3.0
 
 * Update default for 2024/2025 HIV estimates

--- a/inst/model_options.json
+++ b/inst/model_options.json
@@ -170,8 +170,7 @@
         {
           "label": "t_(OPTIONS_ADVANCED_PEPFAR_PROJECTION_CALENNDAR_QUARTERS_LABEL)",
           "controls": [
-            "<+calendar_quarter_t4+>",
-            "<+calendar_quarter_t5+>"	      
+            "<+calendar_quarter_t4+>"
           ]
         },	  
         {


### PR DESCRIPTION
Implements model options page UI update coinciding with https://github.com/mrc-ide/naomi/pull/465